### PR TITLE
Key cached response by varied headers

### DIFF
--- a/lib/guard.js
+++ b/lib/guard.js
@@ -72,6 +72,19 @@
       return fresh(requestHeaders, cached);
     };
 
+    Guard.prototype.key = function(req, res) {
+      var header, key, _i, _len, _ref, _ref1;
+      key = {
+        url: req.originalUrl || req.url
+      };
+      _ref1 = ((_ref = res.get('Vary')) != null ? _ref.split(/, */) : void 0) || [];
+      for (_i = 0, _len = _ref1.length; _i < _len; _i++) {
+        header = _ref1[_i];
+        key[header.toLowerCase()] = req.get(header);
+      }
+      return key;
+    };
+
     Guard.prototype.middleware = function(options) {
       var guard, ttl;
       if (options == null) {
@@ -80,7 +93,7 @@
       ttl = options.ttl || options.maxAge || -1;
       guard = this;
       return function(req, res, next) {
-        var url;
+        var key;
         if (req.method !== 'GET') {
           return next();
         }
@@ -98,8 +111,8 @@
           }
           return delete this._headers['set-cookie'];
         };
-        url = req.originalUrl || req.url;
-        return guard.store.get(url, function(err, cached) {
+        key = guard.key(req, res);
+        return guard.store.get(key, function(err, cached) {
           var expressAddedEtag, name, send, _i, _len, _ref;
           if (err != null) {
             return next(err);
@@ -110,18 +123,18 @@
               name = _ref[_i];
               delete req.headers[name];
             }
-            guard.invalidate(url, function(err) {
+            guard.invalidate(key, function(err) {
               if (err != null) {
-                return guard.emit('error', "Error expiring headers for path '" + url + "'", err);
+                return guard.emit('error', "Error expiring headers for '" + (JSON.stringify(key)) + "'", err);
               }
             });
           } else if ((cached != null) && guard.fresh(req.headers, cached.headers)) {
-            guard.emit('hit', url, cached);
+            guard.emit('hit', key, cached);
             res.set(cached.headers);
             res.set('X-Connect-Guard', 'hit');
             return res.send(304);
           }
-          guard.emit('miss', url, cached);
+          guard.emit('miss', key, cached);
           res.set('X-Connect-Guard', 'miss');
           if (options.maxAge != null) {
             res.cacheable({
@@ -157,14 +170,14 @@
               }
             }
             if (Object.keys(headers).length) {
-              return guard.store.set(url, {
+              return guard.store.set(key, {
                 createdAt: new Date(),
                 headers: headers
               }, function(err) {
                 if (err != null) {
-                  return guard.emit('error', "Error storing headers for path '" + url + "'", err);
+                  return guard.emit('error', "Error storing headers for '" + (JSON.stringify(key)) + "'", err);
                 }
-                return guard.emit('add', url, headers);
+                return guard.emit('add', key, headers);
               });
             }
           });

--- a/lib/memory_store.js
+++ b/lib/memory_store.js
@@ -5,7 +5,7 @@
   normalizeKey = function(key) {
     if (typeof key === 'string') {
       key = {
-        path: key
+        url: key
       };
     }
     return JSON.stringify(key);

--- a/src/memory_store.coffee
+++ b/src/memory_store.coffee
@@ -1,6 +1,6 @@
 normalizeKey = (key) ->
   if typeof key is 'string'
-    key = path: key
+    key = url: key
   JSON.stringify key
 
 

--- a/test/memory_store_test.coffee
+++ b/test/memory_store_test.coffee
@@ -8,7 +8,7 @@ describe 'MemoryStore', ->
     store = new MemoryStore()
 
   describe '::set', ->
-    describe 'given a path and response headers', ->
+    describe 'given a url and response headers', ->
       beforeEach (done) ->
         store.set '/users',
           createdAt: new Date()
@@ -16,15 +16,15 @@ describe 'MemoryStore', ->
             Etag: '123'
           , done
 
-      it 'saves the response headers for future requests for this path', (done) ->
+      it 'saves the response headers for future requests for this url', (done) ->
         store.get '/users', (err, cached) ->
           expect(cached.headers).to.be.ok()
           done(err)
 
-    describe 'given a request path, varied request headers, and response headers', ->
+    describe 'given a request url, varied request headers, and response headers', ->
       beforeEach (done) ->
         store.set {
-          path: '/users'
+          url: '/users'
           'user-agent': 'chrome'
         }, {
           createdAt: new Date()
@@ -32,26 +32,26 @@ describe 'MemoryStore', ->
             Etag: '123'
         }, done
 
-      it 'saves the response headers for future requests for this path and header combination', (done) ->
-        store.get path: '/users', 'user-agent': 'chrome', (err, cached) ->
+      it 'saves the response headers for future requests for this url and header combination', (done) ->
+        store.get url: '/users', 'user-agent': 'chrome', (err, cached) ->
           expect(cached.headers).to.be.ok()
           done(err)
 
-      it 'is stored separetly from other header permuatations for the same path', (done) ->
+      it 'is stored separetly from other header permuatations for the same url', (done) ->
         store.set {
-          path: '/users'
+          url: '/users'
           'user-agent': 'iOS'
         }, {
           createdAt: new Date()
           headers:
             Etag: '456'
         }, (err) ->
-          store.get path: '/users', 'user-agent': 'chrome', (err, cached) ->
+          store.get url: '/users', 'user-agent': 'chrome', (err, cached) ->
             expect(cached.headers.Etag).to.be '123'
             done(err)
 
   describe '::get', ->
-    describe 'given the path of a previously cached response', ->
+    describe 'given the url of a previously cached response', ->
       headers = Etag: '123'
       beforeEach (done) ->
         store.set '/users',
@@ -64,14 +64,14 @@ describe 'MemoryStore', ->
           expect(cached.headers).to.eql headers
           done(err)
 
-    describe 'given a path with no cached response', ->
+    describe 'given a url with no cached response', ->
       it 'returns undefined', (done) ->
         store.get '/users', (err, cached) ->
           expect(cached).to.be undefined
           done(err)
 
   describe '::delete', ->
-    describe 'given the path of a previously cached response', ->
+    describe 'given the url of a previously cached response', ->
       beforeEach (done) ->
         store.set '/users',
           createdAt: new Date()
@@ -79,7 +79,7 @@ describe 'MemoryStore', ->
             Etag: '123'
           , done
 
-      it 'dumps the cached response for that path', (done) ->
+      it 'dumps the cached response for that url', (done) ->
         store.delete '/users', (err, cached) ->
           store.get '/users', (err, cached) ->
             expect(cached).to.be undefined


### PR DESCRIPTION
With these changes, connect-guard will store separate freshness information based on the request headers listed in the `Vary` response header.  Useful for serving different content to different user-agents.  `Vary` headers must be set in middleware run before connect-guard.  See the example below

``` coffee
app.get '/users', (req, res, next) ->
  res.set 'Vary', 'User-Agent'
  next()
app.get '/users', guard()
app.get '/users', (req, res) ->
  # ...
```
